### PR TITLE
feat: allow manual items in POS

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,6 +69,7 @@ const App = () => {
   const videoRef = useRef(null);
   const [showAddProductForm, setShowAddProductForm] = useState(false);
   const [newProductData, setNewProductData] = useState({ name: '', price: 0, stock: 0 });
+  const [manualItemData, setManualItemData] = useState({ name: '', price: 0, quantity: 1 });
 
   // Ticket State
   const [currentSaleId, setCurrentSaleId] = useState(null);
@@ -231,6 +232,21 @@ const App = () => {
     }
   };
 
+  const handleAddManualItem = (itemData) => {
+    if (!itemData.name || itemData.price <= 0 || itemData.quantity <= 0) {
+      console.warn('Datos del producto manual incompletos.');
+      return;
+    }
+    const manualItem = {
+      id: `manual-${Date.now()}`,
+      name: itemData.name,
+      price: parseFloat(itemData.price),
+      quantity: parseInt(itemData.quantity, 10),
+    };
+    setCart(prev => [...prev, manualItem]);
+    setManualItemData({ name: '', price: 0, quantity: 1 });
+  };
+
   const handleUpdateCartItem = (id, change) => {
     setCart(prevCart => {
       const updatedCart = prevCart.map(item => {
@@ -257,6 +273,7 @@ const App = () => {
       const salesPath = `/artifacts/${typeof __app_id !== 'undefined' ? __app_id : 'default-app'}/public/data/sales`;
 
       for (const item of cart) {
+        if (!products[item.id]) continue;
         const productRef = doc(db, productsPath, item.id);
         const productSnap = await getDoc(productRef);
         if (!productSnap.exists() || productSnap.data().stock < item.quantity) {
@@ -266,6 +283,7 @@ const App = () => {
       }
 
       cart.forEach(item => {
+        if (!products[item.id]) return;
         const productRef = doc(db, productsPath, item.id);
         batch.update(productRef, {
           stock: products[item.id].stock - item.quantity,
@@ -331,7 +349,10 @@ const App = () => {
           setShowAddProductForm={setShowAddProductForm}
           newProductData={newProductData}
           setNewProductData={setNewProductData}
+          manualItemData={manualItemData}
+          setManualItemData={setManualItemData}
           handleAddProduct={handleAddProduct}
+          handleAddManualItem={handleAddManualItem}
           handleUpdateCartItem={handleUpdateCartItem}
           handleRemoveCartItem={handleRemoveCartItem}
           handleCheckout={handleCheckout}

--- a/src/components/views/PosView.jsx
+++ b/src/components/views/PosView.jsx
@@ -10,7 +10,10 @@ const PosView = ({
   showAddProductForm,
   newProductData,
   setNewProductData,
+  manualItemData,
+  setManualItemData,
   handleAddProduct,
+  handleAddManualItem,
   handleUpdateCartItem,
   handleRemoveCartItem,
   handleCheckout
@@ -79,6 +82,53 @@ const PosView = ({
             </div>
           </div>
         )}
+
+        {/* Agregar producto manual */}
+        <div className="bg-white rounded-2xl shadow-lg border mb-6 mt-4">
+          <div className="px-6 pt-6">
+            <div className="text-xl font-bold text-green-500 mb-4">Agregar producto manual</div>
+            <div className="flex flex-col gap-4">
+              <div>
+                <label htmlFor="manual-name" className="block text-gray-700 font-semibold mb-1">Nombre</label>
+                <input
+                  id="manual-name"
+                  className="w-full rounded-lg border px-4 py-2 bg-gray-50 text-gray-800 shadow focus:ring-2 focus:ring-blue-400 transition"
+                  placeholder="Nombre del producto"
+                  value={manualItemData.name}
+                  onChange={e => setManualItemData({ ...manualItemData, name: e.target.value })}
+                />
+              </div>
+              <div>
+                <label htmlFor="manual-price" className="block text-gray-700 font-semibold mb-1">Precio</label>
+                <input
+                  id="manual-price"
+                  type="number"
+                  className="w-full rounded-lg border px-4 py-2 bg-gray-50 text-gray-800 shadow focus:ring-2 focus:ring-blue-400 transition"
+                  placeholder="Precio"
+                  value={manualItemData.price}
+                  onChange={e => setManualItemData({ ...manualItemData, price: parseFloat(e.target.value) })}
+                />
+              </div>
+              <div>
+                <label htmlFor="manual-quantity" className="block text-gray-700 font-semibold mb-1">Cantidad</label>
+                <input
+                  id="manual-quantity"
+                  type="number"
+                  className="w-full rounded-lg border px-4 py-2 bg-gray-50 text-gray-800 shadow focus:ring-2 focus:ring-blue-400 transition"
+                  placeholder="Cantidad"
+                  value={manualItemData.quantity}
+                  onChange={e => setManualItemData({ ...manualItemData, quantity: parseInt(e.target.value, 10) })}
+                />
+              </div>
+            </div>
+            <button
+              onClick={() => handleAddManualItem(manualItemData)}
+              className="mt-6 w-full md:w-auto px-6 py-2 rounded-lg bg-green-500 text-white font-semibold shadow hover:bg-green-600 transition"
+            >
+              Agregar al Carrito
+            </button>
+          </div>
+        </div>
       </div>
 
       {/* Carrito */}


### PR DESCRIPTION
## Summary
- enable adding custom products to cart without barcode
- skip stock updates for manual cart items at checkout
- show manual product form in POS interface

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: __app_id is not defined, etc.)


------
https://chatgpt.com/codex/tasks/task_e_688e48ed6a5c832c8c532a9e2432c3e3